### PR TITLE
[BUGFIX] hasSubpages on localized menus

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -475,12 +475,19 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
                 $pages[$index]['current'] = true;
                 $class[] = $this->arguments['classCurrent'];
             }
-            if (0 < count($this->getMenu($originalPageUid))) {
-                $pages[$index]['hasSubPages'] = true;
-                //TODO: Remove deprecated argument in next major version
-                $class[] = $this->arguments[
-                    $this->hasArgument('classHasSubpages') ? 'classHasSubpages' : 'classHasSubPages'
-                ];
+            // simply check if current page uid can have sub-pages
+            $subMenuPages = $this->getMenu($originalPageUid);
+            if (0 < count($subMenuPages)) {
+                // make recursive call to check if all sub-pages are valid for current language (see above)
+                $parsedMenu = $this->parseMenu($subMenuPages);
+                if (0 < count($parsedMenu)) {
+                    $pages[$index]['hasSubPages'] = true;
+                    
+                    //TODO: Remove deprecated argument in next major version
+                    $class[] = $this->arguments[
+                        $this->hasArgument('classHasSubpages') ? 'classHasSubpages' : 'classHasSubPages'
+                    ];
+                }
             }
             if (1 === $count) {
                 $class[] = $this->arguments['classFirst'];


### PR DESCRIPTION
this will fix a similar issue as in the previous closed issue https://github.com/FluidTYPO3/vhs/issues/904

for a menu like this:
- Item 1 (localized)
  - Subitem 1.1 (not localized)
  - Subitem 1.2 (not localized)

... the Viewhelper renders the localized "Item 1" with hasSubpages=true in any/all languages
This fix extends the submenu check inside parseMenu method and makes a recursive call (on parseMenu method) to check if the submenu isn't empty after processing. Only if the processed/parsed menu isn't empty we can be sure that the current menu item has sub-pages ;)